### PR TITLE
dev / logging 로직 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   jogak_backend_app:
     image: mallangc/tocktock-backend:1.0.1
     container_name: tocktock-backend
+    restart: always
     environment:
       TZ: Asia/Seoul
       DB_URL: ${DB_URL}
@@ -15,6 +16,15 @@ services:
       - "8080:8080"
     volumes:
       - /etc/localtime:/etc/localtime:ro
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "1"
+    deploy:
+      resources:
+        limits:
+          memory: 600m
     depends_on:
       - redis
 


### PR DESCRIPTION
- 계속 EC2에 쌓이는 로그로 메모리 부족 현상 발생으로 인해 도커 logging을 추가
- 서버가 멈추면 다시 실행하는 기능 추가